### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM registry1.dso.mil/ironbank/redhat/openjdk/openjdk8:1.8.0
-#FROM registry1.dso.mil/ironbank/redhat/openjdk/openjdk8-slim:1.8.0
+#FROM registry1.dso.mil/ironbank/redhat/openjdk/openjdk8:1.8.0
+FROM registry1.dso.mil/ironbank/redhat/openjdk/openjdk8-slim:1.8.0
 #FROM registry.access.redhat.com/ubi8/openjdk-8-runtime:1.14
 #FROM openjdk:8-jre-alpine
 


### PR DESCRIPTION
uses openjdk8-slim from iron bank